### PR TITLE
2020年の憲法記念日の振替休日が漏れている問題を修正

### DIFF
--- a/src/Resources/config/2020.yml
+++ b/src/Resources/config/2020.yml
@@ -38,6 +38,10 @@
     caption: 子供の日
     month: '5'
     date: '5'
+'2020-05-06':
+    caption: 振替休日
+    month: '5'
+    date: '6'
 '2020-07-23':
     caption: 海の日
     month: '7'


### PR DESCRIPTION
2020/05/06(水)は同年の憲法記念日の振替休日にあたりますが、[Japanese.Holiday/src/Resources/config/2020.yml](https://github.com/77web/Japanese.Holiday/blob/master/src/Resources/config/2020.yml)には記載がありません。
PRを提出しておりますので問題なければマージをお願いします。