### PR TITLE
Apply moving of holidays for 2021 Tokyo Olympics to 2021.yaml / 2021年の祝日定義をオリンピックによる祝日移動に対応させる

### DIFF
--- a/src/Resources/config/2021.yml
+++ b/src/Resources/config/2021.yml
@@ -42,6 +42,10 @@
     caption: 山の日
     month: '8'
     date: '8'
+'2021-08-09':
+    caption: 振替休日
+    month: '8'
+    date: '9'
 '2021-09-20':
     caption: 敬老の日
     month: '9'

--- a/src/Resources/config/2021.yml
+++ b/src/Resources/config/2021.yml
@@ -34,14 +34,14 @@
     caption: 子供の日
     month: '5'
     date: '5'
-'2021-07-19':
+'2021-07-22':
     caption: 海の日
     month: '7'
-    date: '19'
-'2021-08-11':
+    date: '22'
+'2021-08-08':
     caption: 山の日
     month: '8'
-    date: '11'
+    date: '8'
 '2021-09-20':
     caption: 敬老の日
     month: '9'
@@ -50,10 +50,10 @@
     caption: 秋分の日
     month: '9'
     date: '23'
-'2021-10-11':
+'2021-07-23':
     caption: スポーツの日
-    month: '10'
-    date: '11'
+    month: '07'
+    date: '23'
 '2021-11-03':
     caption: 文化の日
     month: '11'


### PR DESCRIPTION
close #30 

https://www.kantei.go.jp/jp/headline/tokyo2020/shukujitsu.html